### PR TITLE
Update AuthTestResponse to include bot_id instead of enterprise_id

### DIFF
--- a/slack.go
+++ b/slack.go
@@ -41,8 +41,7 @@ type AuthTestResponse struct {
 	User   string `json:"user"`
 	TeamID string `json:"team_id"`
 	UserID string `json:"user_id"`
-	// EnterpriseID is only returned when an enterprise id present
-	EnterpriseID string `json:"enterprise_id,omitempty"`
+	BotID  string `json:"bot_id"`
 }
 
 type authTestResponseFull struct {


### PR DESCRIPTION
Pending https://github.com/slack-go/slack/pull/778 to be merged